### PR TITLE
Hotfix/autoconf gnu extensions config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_TYPE_SSIZE_T
 
 # Checks for library functions.
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([socket strdup strerror vasprintf asprintf])
+AC_CHECK_FUNCS([socket strdup strerror vasprintf asprintf], [], [exit 1])
 
 AM_INIT_AUTOMAKE([-Wall -Werror])
 AM_PROG_AR

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,9 @@
 AC_INIT([libstatsdc], [0.5], [mina@naguib.ca])
 
+AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([build-aux])
+# Enable GNU extensions
+AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile libstatsdc/Makefile src/Makefile])
 AC_CONFIG_SRCDIR([libstatsdc/statsdc.h])
@@ -16,7 +19,7 @@ AC_TYPE_SSIZE_T
 
 # Checks for library functions.
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([socket strdup strerror])
+AC_CHECK_FUNCS([socket strdup strerror vasprintf asprintf])
 
 AM_INIT_AUTOMAKE([-Wall -Werror])
 AM_PROG_AR

--- a/libstatsdc/statsdc.h
+++ b/libstatsdc/statsdc.h
@@ -5,6 +5,8 @@
  *
  */
 
+#include <config.h>
+
 #ifndef _STATSDC_H
 
 #ifdef __cplusplus


### PR DESCRIPTION
Ensure that GNU extensions are properly managed by `autoconf`, error-out if the extensions are unavailable.

`libstatsdc` requires the extensions for logging errors and doesn't have any conditional fallbacks in cases where they aren't found. The "error-out" behavior should be removed once proper fallbacks are implemented.