### PR TITLE
Remove import of autotools-generated <config.h>

### DIFF
--- a/src/statsdc.h
+++ b/src/statsdc.h
@@ -5,8 +5,6 @@
  *
  */
 
-#include <config.h>
-
 #ifndef _STATSDC_H
 
 #ifdef __cplusplus


### PR DESCRIPTION
Since autotools was removed, this file will never be found in normal circumstances.